### PR TITLE
Improve freeze avoidance logic

### DIFF
--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -20,6 +20,7 @@ public:
 	vec2 m_aMousePos[NUM_DUMMIES];
 	vec2 m_aMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
+	vec2 m_aLastMousePos[NUM_DUMMIES];
 
 	int m_aAmmoCount[NUM_WEAPONS];
 
@@ -53,5 +54,9 @@ private:
 	static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData);
 	static void ConKeyInputNextPrevWeapon(IConsole::IResult *pResult, void *pUserData);
 	void ApplyAvoidFreeze(int Dummy);
+	bool DetectFreezeAhead(const vec2 &Pos, float Direction, float Distance, float StepSize, float &ClosestEdge) const;
+	bool IsPlayerOnGround(const vec2 &Pos) const;
+	bool IsPlayerActive(int Dummy);
+	bool IsMouseMoved(int Dummy);
 };
 #endif


### PR DESCRIPTION
## Summary
- add cooldown tracking, mouse activity checks, and configurable timing helpers to the freeze avoidance logic
- simulate nearby tiles to pick safer directions and prevent walking into freeze tiles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd477e867c832c90fef6557691b5dc